### PR TITLE
Enhance CI workflow with security permissions and GitHub Pages deploy…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,12 @@ jobs:
 
   security:
     runs-on: ubuntu-latest
+    
+    # Add permissions for security scanning
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
 
     steps:
       - name: Checkout code
@@ -270,6 +276,17 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    
+    # Add permissions for GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    
+    # Environment for GitHub Pages deployment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout code
@@ -289,12 +306,19 @@ jobs:
             sed -i 's/INPUT                  =/INPUT                  = include\/ src\/ README.md/' Doxyfile
             sed -i 's/RECURSIVE              = NO/RECURSIVE              = YES/' Doxyfile
             sed -i 's/GENERATE_HTML          = YES/GENERATE_HTML          = YES/' Doxyfile
+            sed -i 's/OUTPUT_DIRECTORY       =/OUTPUT_DIRECTORY       = docs/' Doxyfile
           fi
 
           doxygen Doxyfile
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./html
+          path: docs/html
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This pull request updates the GitHub Actions CI workflow to improve security, enable proper permissions for GitHub Pages deployment, and modernize the deployment process. The changes mainly focus on configuring permissions for jobs and updating the documentation deployment steps.

**Workflow permissions and security updates:**

* Added explicit permissions for the `security` job to allow reading repository contents, writing security events, and reading actions, improving security scanning capabilities.

**GitHub Pages deployment improvements:**

* Configured the `deploy` job with the necessary permissions for GitHub Pages: read access to contents, write access to pages, and write access to id-token, ensuring secure and successful deployments.
* Set up a dedicated environment for GitHub Pages deployment, including a deployment URL output.
* Updated the Doxygen configuration to output documentation to the `docs` directory, aligning with the new deployment process.
* Replaced the deprecated `peaceiris/actions-gh-pages` action with the recommended GitHub Actions: `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages`, streamlining and modernizing the deployment workflow.…ment setup