### PR TITLE
Add compression support to BFC library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake clang-format clang-tidy
+          sudo apt-get install -y build-essential cmake clang-format clang-tidy libzstd-dev
 
       - name: Install dependencies (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          brew install clang-format || true
+          brew install clang-format zstd || true
           # cmake is already available on macOS runners
 
       - name: Set up environment
@@ -49,7 +49,8 @@ jobs:
           cmake -B build \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_C_COMPILER=${{ matrix.cc }} \
-            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+            -DBFC_WITH_ZSTD=ON
 
       - name: Build
         run: cmake --build build --config ${{ matrix.build_type }} -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
@@ -75,6 +76,16 @@ jobs:
           ./build/bin/bfc info test.bfc
           ./build/bin/bfc verify test.bfc
           ./build/bin/bfc verify --deep test.bfc
+          
+          # Test compression functionality
+          ./build/bin/bfc create -c zstd test_compressed.bfc test_data/
+          ./build/bin/bfc info test_compressed.bfc hello.txt
+          ./build/bin/bfc verify test_compressed.bfc
+          
+          # Test different compression levels
+          ./build/bin/bfc create -c zstd -l 1 test_fast.bfc test_data/
+          ./build/bin/bfc create -c zstd -l 6 test_balanced.bfc test_data/
+          ./build/bin/bfc info test_balanced.bfc hello.txt
 
           # Test extraction
           mkdir -p extract_test
@@ -87,12 +98,15 @@ jobs:
           [ -f subdir/nested.txt ] && echo "nested.txt extracted"
 
           cd ..
-          rm -rf extract_test test.bfc test_data
+          rm -rf extract_test test.bfc test_data test_compressed.bfc test_fast.bfc test_balanced.bfc
 
       - name: Run benchmarks
         run: |
           cd build/benchmarks
           ./benchmark_crc32c
+          
+          # Run compression benchmark (quick test)
+          timeout 60s ./benchmark_compress || gtimeout 60s ./benchmark_compress || echo "Compression benchmark completed or timed out"
 
           # Run with timeout (different commands for Linux vs macOS)
           if command -v timeout >/dev/null 2>&1; then
@@ -131,13 +145,14 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake lcov bc
+          sudo apt-get install -y build-essential cmake lcov bc libzstd-dev
 
       - name: Configure CMake with coverage
         run: |
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Debug \
             -DBFC_COVERAGE=ON \
+            -DBFC_WITH_ZSTD=ON \
             -DBFC_BUILD_BENCHMARKS=OFF \
             -DCMAKE_C_FLAGS="--coverage -fprofile-arcs -ftest-coverage"
 
@@ -222,10 +237,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake clang-tidy cppcheck
+          sudo apt-get install -y build-essential cmake clang-tidy cppcheck libzstd-dev
 
       - name: Configure CMake
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Debug
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBFC_WITH_ZSTD=ON
 
       - name: Run clang-tidy
         run: |
@@ -263,11 +278,11 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake
+          sudo apt-get install -y build-essential cmake libzstd-dev
 
       - name: Build for CodeQL
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=Release -DBFC_BUILD_BENCHMARKS=OFF
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -DBFC_WITH_ZSTD=ON -DBFC_BUILD_BENCHMARKS=OFF
           cmake --build build
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.platform == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake clang rpm
+          sudo apt-get install -y build-essential cmake clang rpm libzstd-dev
           # Install fpm for package creation
           sudo gem install fpm
 
@@ -48,8 +48,8 @@ jobs:
         if: matrix.platform == 'macos'
         run: |
           echo "cmake is already available on macOS runners"
-          # Install create-dmg for DMG creation
-          brew install create-dmg
+          # Install create-dmg for DMG creation and zstd for compression
+          brew install create-dmg zstd
 
       - name: Build Release
         env:
@@ -60,7 +60,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=${{ matrix.cc }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
-            -DCMAKE_INSTALL_PREFIX=/usr/local
+            -DCMAKE_INSTALL_PREFIX=/usr/local \
+            -DBFC_WITH_ZSTD=ON
 
           cmake --build build --config Release -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ cmake-build-*/
 CMakeCache.txt
 CMakeFiles/
 cmake_install.cmake
-Makefile
 *.cmake
 CTestTestfile.txt
 _deps/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ endif()
 if(BFC_WITH_ZSTD)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(ZSTD REQUIRED libzstd)
+    message(STATUS "ZSTD compression support enabled")
 endif()
 
 # Include directories

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,152 @@
+# BFC Project Makefile
+# Copyright 2021 zombocoder (Taras Havryliak)
+# Licensed under the Apache License, Version 2.0
+
+# Build configuration
+BUILD_DIR := build
+CMAKE_BUILD_TYPE ?= Debug
+
+# Source directories
+SRC_DIRS := src include tests examples
+SOURCE_FILES := $(shell find $(SRC_DIRS) -name "*.c" -o -name "*.h" 2>/dev/null)
+
+# Coverage configuration
+COVERAGE_DIR := $(BUILD_DIR)/coverage
+COVERAGE_INFO := $(COVERAGE_DIR)/coverage.info
+COVERAGE_HTML := $(COVERAGE_DIR)/html
+COVERAGE_THRESHOLD := 90
+
+.PHONY: all clean configure build test format format-check format-fix coverage coverage-report cppcheck help
+
+# Default target
+all: build test
+
+# Help target
+help:
+	@echo "BFC Project Makefile"
+	@echo ""
+	@echo "Available targets:"
+	@echo "  build           - Build the project"
+	@echo "  test            - Run all tests"
+	@echo "  format-check    - Check code formatting (dry-run)"
+	@echo "  format-fix      - Fix code formatting"
+	@echo "  coverage        - Run coverage tests with lcov"
+	@echo "  coverage-report - Generate HTML coverage report"
+	@echo "  cppcheck        - Run static analysis with cppcheck"
+	@echo "  clean           - Clean build artifacts"
+	@echo "  help            - Show this help message"
+	@echo ""
+	@echo "Variables:"
+	@echo "  CMAKE_BUILD_TYPE - Build type (Debug, Release) [default: Debug]"
+
+# Configure CMake
+configure:
+	@echo "Configuring CMake build..."
+	cmake -B $(BUILD_DIR) \
+		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+		-DBFC_WITH_ZSTD=ON
+
+# Build the project
+build: configure
+	@echo "Building project..."
+	cmake --build $(BUILD_DIR)
+
+# Run tests
+test: build
+	@echo "Running tests..."
+	ctest --test-dir $(BUILD_DIR) --output-on-failure
+
+# Check code formatting (dry-run)
+format-check:
+	@echo "Checking code formatting..."
+	@if [ -z "$(SOURCE_FILES)" ]; then \
+		echo "No source files found"; \
+		exit 1; \
+	fi
+	@echo "Checking $(words $(SOURCE_FILES)) files..."
+	clang-format --dry-run --Werror $(SOURCE_FILES)
+	@echo "Format check passed!"
+
+# Fix code formatting
+format-fix:
+	@echo "Fixing code formatting..."
+	@if [ -z "$(SOURCE_FILES)" ]; then \
+		echo "No source files found"; \
+		exit 1; \
+	fi
+	@echo "Formatting $(words $(SOURCE_FILES)) files..."
+	clang-format -i $(SOURCE_FILES)
+	@echo "Code formatting applied!"
+
+# Run coverage tests
+coverage: configure
+	@echo "Running coverage tests..."
+	@mkdir -p $(COVERAGE_DIR)
+	
+	# Build with coverage flags
+	cmake --build $(BUILD_DIR)
+	
+	# Initialize coverage counters
+	lcov --directory $(BUILD_DIR) --zerocounters --ignore-errors unused
+	
+	# Run tests
+	ctest --test-dir $(BUILD_DIR) --output-on-failure
+	
+	# Capture coverage data
+	lcov --directory $(BUILD_DIR) \
+		--capture \
+		--output-file $(COVERAGE_INFO) \
+		--rc branch_coverage=1 \
+		--ignore-errors deprecated,unsupported,unused
+	
+	# Remove external libraries and test files from coverage
+	lcov --remove $(COVERAGE_INFO) \
+		'*/tests/*' \
+		'*/examples/*' \
+		'*/build/*' \
+		--output-file $(COVERAGE_INFO).clean \
+		--rc branch_coverage=1 \
+		--ignore-errors deprecated,unsupported,unused
+	
+	@mv $(COVERAGE_INFO).clean $(COVERAGE_INFO)
+	@echo "Coverage data collected at: $(COVERAGE_INFO)"
+
+# Generate HTML coverage report
+coverage-report: coverage
+	@echo "Generating HTML coverage report..."
+	@mkdir -p $(COVERAGE_HTML)
+	
+	genhtml $(COVERAGE_INFO) \
+		--output-directory $(COVERAGE_HTML) \
+		--title "BFC Coverage Report" \
+		--show-details \
+		--rc branch_coverage=1 \
+		--ignore-errors deprecated,unsupported,unused
+	
+	@echo "Coverage report generated at: $(COVERAGE_HTML)/index.html"
+	@echo "Open with: open $(COVERAGE_HTML)/index.html"
+
+# Clean build artifacts
+clean:
+	@echo "Cleaning build artifacts..."
+	@rm -rf $(BUILD_DIR)
+	@echo "Clean complete!"
+
+# Run static analysis with cppcheck
+cppcheck:
+	@echo "Running static analysis with cppcheck..."
+	@which cppcheck > /dev/null || (echo "Error: cppcheck not found. Install with: apt-get install cppcheck" && exit 1)
+	cppcheck --enable=all --inconclusive --xml --xml-version=2 \
+		--suppress=missingIncludeSystem \
+		--suppress=unmatchedSuppression \
+		src/ include/ 2> cppcheck.xml || true
+	@echo "Static analysis complete. Results saved to cppcheck.xml"
+	@echo "To view results in terminal:"
+	@echo "  cppcheck --enable=all --inconclusive src/ include/"
+
+# Convenience aliases
+fmt-check: format-check
+fmt-fix: format-fix
+fmt: format-fix
+cov: coverage
+cov-report: coverage-report

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A high-performance, single-file container format for storing files and directori
 - **Single-file containers** - Everything in one `.bfc` file
 - **POSIX metadata** - Preserves permissions, timestamps, and file types
 - **Fast random access** - O(log N) file lookup with sorted index
+- **Optional compression** - ZSTD compression with intelligent content analysis
 - **Integrity validation** - CRC32C checksums with hardware acceleration
 - **Cross-platform** - Works on Linux, macOS, and other Unix systems
 - **Crash-safe writes** - Atomic container creation with index at EOF
@@ -96,6 +97,40 @@ bfc create -b 8192 archive.bfc /data/
 # Force overwrite existing container
 bfc create -f archive.bfc /path/to/files/
 ```
+
+### Compression support
+
+BFC supports optional file compression to reduce storage space. When built with ZSTD support (`-DBFC_WITH_ZSTD=ON`), containers can automatically compress files based on content analysis.
+
+```bash
+# Enable ZSTD compression (default level: 3)
+bfc create -c zstd archive.bfc /path/to/files/
+
+# Set specific compression level (1-22, higher = better compression)
+bfc create -c zstd -l 6 archive.bfc /path/to/files/
+
+# Set compression threshold (only compress files larger than size)
+bfc create -c zstd -t 1024 archive.bfc /path/to/files/
+
+# Disable compression explicitly
+bfc create -c none archive.bfc /path/to/files/
+
+# View compression information
+bfc info archive.bfc path/to/file.txt
+# Shows:
+#   Compression: zstd
+#   Size: 1048576 bytes (1.0 MiB)
+#   Stored size: 524288 bytes (512.0 KiB)
+#   Storage ratio: 50.0%
+#   Compression ratio: 50.0%
+```
+
+**Compression behavior:**
+- **Automatic detection** - BFC analyzes file content to recommend compression
+- **Small file threshold** - Files smaller than 64 bytes are never compressed
+- **Content analysis** - Text files, repetitive data, and files with patterns compress well
+- **Transparent extraction** - Compressed files are automatically decompressed on extraction
+- **Integrity validation** - CRC32C checksums protect both original and compressed data
 
 ### Listing contents
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -35,17 +35,34 @@ target_include_directories(benchmark_crc32c PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src/lib)
 
+# Compression benchmark
+add_executable(benchmark_compress benchmark_compress.c)
+target_link_libraries(benchmark_compress bfc)
+target_include_directories(benchmark_compress PRIVATE 
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src/lib)
+
 # All benchmarks runner
 add_executable(benchmark_all benchmark_all.c)
 target_include_directories(benchmark_all PRIVATE 
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src/lib)
 
+# Link ZSTD if enabled (needed for static library dependencies)
+if(BFC_WITH_ZSTD)
+    foreach(target benchmark_writer benchmark_reader benchmark_crc32c benchmark_compress)
+        target_link_libraries(${target} ${ZSTD_LIBRARIES})
+        target_link_directories(${target} PRIVATE ${ZSTD_LIBRARY_DIRS})
+        target_compile_definitions(${target} PRIVATE BFC_WITH_ZSTD)
+    endforeach()
+endif()
+
 # Install benchmarks
 install(TARGETS 
         benchmark_writer 
         benchmark_reader 
         benchmark_crc32c
+        benchmark_compress
         benchmark_all
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/benchmarks)
 
@@ -54,6 +71,7 @@ install(FILES
         benchmark_writer.c
         benchmark_reader.c
         benchmark_crc32c.c
+        benchmark_compress.c
         benchmark_all.c
         benchmark_common.h
         CMakeLists.txt
@@ -79,9 +97,15 @@ add_custom_target(bench-crc32c
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Running CRC32C performance benchmark")
 
+add_custom_target(bench-compress
+    COMMAND benchmark_compress
+    DEPENDS benchmark_compress
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Running compression performance benchmark")
+
 add_custom_target(bench-all
     COMMAND benchmark_all
-    DEPENDS benchmark_all benchmark_writer benchmark_reader benchmark_crc32c
+    DEPENDS benchmark_all benchmark_writer benchmark_reader benchmark_crc32c benchmark_compress
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Running all performance benchmarks")
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -68,14 +68,43 @@ Tests checksum computation performance:
 - Measures hardware acceleration effectiveness
 - Evaluates unaligned access penalties
 
-### 4. All Benchmarks Runner (`benchmark_all`)
+### 4. Compression Benchmark (`benchmark_compress`)
+Tests compression and decompression performance with ZSTD:
+
+**Compression Level Test:**
+- Tests compression levels 1, 3, 6, 9, 12 with different content types
+- Compares compressible text vs random data compression ratios
+- Measures write throughput and space savings across compression levels
+
+**Compression Scaling Test:**
+- Tests different file sizes (1KB to 1MB) with and without compression
+- Measures compression effectiveness and performance impact
+- Evaluates compression overhead for various workloads
+
+**Decompression Performance Test:**
+- Benchmarks reading/decompression speed of compressed containers
+- Measures decompression throughput and file processing rates
+- Tests end-to-end compressed file access performance
+
+**Typical Results:**
+- **Compressible content**: 95-99% space savings with ZSTD
+- **Random data**: No compression applied (smart detection)
+- **Write performance**: 90-450 MB/s depending on compression level and file size
+- **Decompression speed**: 500-600 MB/s (often faster than compression)
+
+### 5. All Benchmarks Runner (`benchmark_all`)
 Runs all benchmarks in sequence with system information reporting.
 
 ## Building and Running
 
 ### Build with main project
 ```bash
+# Basic benchmarks
 cmake -S . -B build -DBFC_BUILD_BENCHMARKS=ON
+cmake --build build
+
+# With ZSTD compression support for compression benchmarks
+cmake -S . -B build -DBFC_BUILD_BENCHMARKS=ON -DBFC_WITH_ZSTD=ON
 cmake --build build
 ```
 
@@ -90,6 +119,9 @@ cmake --build build
 # CRC32C benchmark
 ./build/benchmarks/benchmark_crc32c
 
+# Compression benchmark (requires ZSTD support)
+./build/benchmarks/benchmark_compress
+
 # All benchmarks
 ./build/benchmarks/benchmark_all
 ```
@@ -100,6 +132,7 @@ cmake --build build
 make bench-writer
 make bench-reader
 make bench-crc32c
+make bench-compress
 
 # All benchmarks
 make benchmarks

--- a/benchmarks/benchmark_compress.c
+++ b/benchmarks/benchmark_compress.c
@@ -1,0 +1,456 @@
+/*
+ * Copyright 2021 zombocoder (Taras Havryliak)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define _GNU_SOURCE
+#include <bfc.h>
+#include "benchmark_common.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+// Generate compressible content (repeated patterns)
+static void generate_compressible_content(char *buffer, size_t size) {
+    const char *patterns[] = {
+        "This is a sample text with repeating patterns that compress well. ",
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ",
+        "The quick brown fox jumps over the lazy dog. ",
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+    };
+    const int num_patterns = sizeof(patterns) / sizeof(patterns[0]);
+    
+    size_t offset = 0;
+    int pattern_idx = 0;
+    
+    while (offset < size) {
+        const char *pattern = patterns[pattern_idx];
+        size_t pattern_len = strlen(pattern);
+        size_t copy_len = (size - offset < pattern_len) ? size - offset : pattern_len;
+        
+        memcpy(buffer + offset, pattern, copy_len);
+        offset += copy_len;
+        pattern_idx = (pattern_idx + 1) % num_patterns;
+    }
+}
+
+// Generate random content (low compressibility)  
+static void generate_random_content(char *buffer, size_t size) {
+    srand(42); // Fixed seed for reproducible results
+    for (size_t i = 0; i < size; i++) {
+        buffer[i] = (char)(rand() % 256);
+    }
+}
+
+// Benchmark compression with different content types and levels
+static int benchmark_compression_levels(void) {
+    const char *container_base = "/tmp/benchmark_compress";
+    const int num_files = 100;
+    const size_t file_size = 64 * 1024; // 64KB files
+    
+    printf("\n=== Compression Level Benchmark ===\n");
+    printf("Files: %d x %zu KB each\n\n", num_files, file_size / 1024);
+    
+    // Test different compression levels (if ZSTD available)
+    int levels[] = {0, 1, 3, 6, 9, 12}; // 0 = no compression
+    int num_levels = sizeof(levels) / sizeof(levels[0]);
+    
+#ifndef BFC_WITH_ZSTD
+    printf("ZSTD not available - testing only no compression\n");
+    levels[0] = 0;
+    num_levels = 1;
+#endif
+    
+    // Test with different content types
+    struct {
+        const char *name;
+        void (*generator)(char *, size_t);
+    } content_types[] = {
+        {"Compressible Text", generate_compressible_content},
+        {"Random Data", generate_random_content}
+    };
+    int num_content_types = sizeof(content_types) / sizeof(content_types[0]);
+    
+    char *content = malloc(file_size);
+    if (!content) {
+        printf("Failed to allocate content buffer\n");
+        return 1;
+    }
+    
+    printf("%-20s %-10s %-12s %-12s %-12s %-10s %-10s\n", 
+           "Content Type", "Level", "Write MB/s", "Container", "Orig Size", "Ratio", "Space Saved");
+    printf("%-20s %-10s %-12s %-12s %-12s %-10s %-10s\n", 
+           "--------------------", "----------", "------------", "------------", "------------", "----------", "----------");
+    
+    for (int ct = 0; ct < num_content_types; ct++) {
+        // Generate content for this type
+        content_types[ct].generator(content, file_size);
+        
+        for (int lv = 0; lv < num_levels; lv++) {
+            char container[256];
+            snprintf(container, sizeof(container), "%s_%s_l%d.bfc", 
+                    container_base, 
+                    (ct == 0) ? "text" : "random", 
+                    levels[lv]);
+            
+            unlink(container);
+            
+            bfc_t *writer = NULL;
+            int result = bfc_create(container, 4096, 0, &writer);
+            if (result != BFC_OK) continue;
+            
+            // Set compression
+            if (levels[lv] == 0) {
+                bfc_set_compression(writer, BFC_COMP_NONE, 0);
+            } else {
+#ifdef BFC_WITH_ZSTD
+                bfc_set_compression(writer, BFC_COMP_ZSTD, levels[lv]);
+#endif
+            }
+            
+            struct timespec start, end;
+            clock_gettime(CLOCK_MONOTONIC, &start);
+            
+            // Add files
+            uint64_t total_original = 0;
+            for (int i = 0; i < num_files; i++) {
+                char path[64];
+                snprintf(path, sizeof(path), "file_%04d.dat", i);
+                
+                FILE *temp = tmpfile();
+                if (!temp) break;
+                
+                fwrite(content, 1, file_size, temp);
+                rewind(temp);
+                
+                result = bfc_add_file(writer, path, temp, 0644, 0, NULL);
+                fclose(temp);
+                
+                if (result == BFC_OK) {
+                    total_original += file_size;
+                }
+            }
+            
+            result = bfc_finish(writer);
+            bfc_close(writer);
+            
+            clock_gettime(CLOCK_MONOTONIC, &end);
+            
+            if (result != BFC_OK) {
+                printf("%-20s L%-9d FAILED\n", content_types[ct].name, levels[lv]);
+                continue;
+            }
+            
+            // Get container size
+            struct stat st;
+            uint64_t container_size = 0;
+            if (stat(container, &st) == 0) {
+                container_size = st.st_size;
+            }
+            
+            // Calculate metrics
+            double elapsed = benchmark_time_diff(&start, &end);
+            double write_mbps = benchmark_throughput_mbps(total_original, elapsed);
+            double compression_ratio = (total_original > 0) ? 
+                (double)container_size / total_original * 100.0 : 100.0;
+            double space_saved = 100.0 - compression_ratio;
+            
+            char container_size_str[32], orig_size_str[32];
+            benchmark_format_bytes(container_size, container_size_str, sizeof(container_size_str));
+            benchmark_format_bytes(total_original, orig_size_str, sizeof(orig_size_str));
+            
+            printf("%-20s L%-9d %-12.1f %-12s %-12s %-9.1f%% %-9.1f%%\n",
+                   content_types[ct].name,
+                   levels[lv],
+                   write_mbps,
+                   container_size_str,
+                   orig_size_str,
+                   compression_ratio,
+                   (space_saved > 0) ? space_saved : 0.0);
+            
+            unlink(container);
+        }
+        printf("\n");
+    }
+    
+    free(content);
+    return 0;
+}
+
+// Benchmark compression vs no compression for different file sizes
+static int benchmark_compression_scaling(void) {
+    const char *container_base = "/tmp/benchmark_scale";
+    
+    printf("\n=== Compression Scaling Benchmark ===\n");
+    
+    // Test different file sizes
+    struct {
+        int count;
+        size_t size;
+        const char *desc;
+    } test_cases[] = {
+        {10000, 1024, "Small files (1KB x 10k)"},
+        {1000, 10 * 1024, "Medium files (10KB x 1k)"}, 
+        {100, 100 * 1024, "Large files (100KB x 100)"},
+        {10, 1024 * 1024, "Very large files (1MB x 10)"}
+    };
+    int num_cases = sizeof(test_cases) / sizeof(test_cases[0]);
+    
+    char *content = malloc(1024 * 1024); // 1MB buffer
+    if (!content) {
+        printf("Failed to allocate content buffer\n");
+        return 1;
+    }
+    
+    // Generate compressible content
+    generate_compressible_content(content, 1024 * 1024);
+    
+    printf("%-25s %-10s %-12s %-12s %-10s %-12s\n", 
+           "Test Case", "Compress", "Write MB/s", "Files/sec", "Ratio", "Space Saved");
+    printf("%-25s %-10s %-12s %-12s %-10s %-12s\n", 
+           "-------------------------", "----------", "------------", "------------", "----------", "------------");
+    
+    for (int tc = 0; tc < num_cases; tc++) {
+        const char *compression_modes[] = {"None", "ZSTD"};
+        int num_modes = 1;
+#ifdef BFC_WITH_ZSTD
+        num_modes = 2;
+#endif
+        
+        for (int mode = 0; mode < num_modes; mode++) {
+            char container[256];
+            snprintf(container, sizeof(container), "%s_s%zu_c%d_m%d.bfc", 
+                    container_base, test_cases[tc].size, test_cases[tc].count, mode);
+            
+            unlink(container);
+            
+            bfc_t *writer = NULL;
+            int result = bfc_create(container, 4096, 0, &writer);
+            if (result != BFC_OK) continue;
+            
+            // Set compression mode
+            if (mode == 0) {
+                bfc_set_compression(writer, BFC_COMP_NONE, 0);
+            } else {
+#ifdef BFC_WITH_ZSTD
+                bfc_set_compression(writer, BFC_COMP_ZSTD, 3);
+#endif
+            }
+            
+            struct timespec start, end;
+            clock_gettime(CLOCK_MONOTONIC, &start);
+            
+            // Add files
+            uint64_t total_bytes = 0;
+            for (int i = 0; i < test_cases[tc].count; i++) {
+                char path[64];
+                snprintf(path, sizeof(path), "file_%06d.dat", i);
+                
+                FILE *temp = tmpfile();
+                if (!temp) break;
+                
+                fwrite(content, 1, test_cases[tc].size, temp);
+                rewind(temp);
+                
+                result = bfc_add_file(writer, path, temp, 0644, 0, NULL);
+                fclose(temp);
+                
+                if (result == BFC_OK) {
+                    total_bytes += test_cases[tc].size;
+                }
+            }
+            
+            result = bfc_finish(writer);
+            bfc_close(writer);
+            
+            clock_gettime(CLOCK_MONOTONIC, &end);
+            
+            if (result != BFC_OK) {
+                printf("%-25s %-10s FAILED\n", test_cases[tc].desc, compression_modes[mode]);
+                continue;
+            }
+            
+            // Get container size
+            struct stat st;
+            uint64_t container_size = 0;
+            if (stat(container, &st) == 0) {
+                container_size = st.st_size;
+            }
+            
+            // Calculate metrics
+            double elapsed = benchmark_time_diff(&start, &end);
+            double write_mbps = benchmark_throughput_mbps(total_bytes, elapsed);
+            double files_per_sec = benchmark_ops_per_sec(test_cases[tc].count, elapsed);
+            double compression_ratio = (total_bytes > 0) ? 
+                (double)container_size / total_bytes * 100.0 : 100.0;
+            double space_saved = 100.0 - compression_ratio;
+            
+            printf("%-25s %-10s %-12.1f %-12.1f %-9.1f%% %-11.1f%%\n",
+                   test_cases[tc].desc,
+                   compression_modes[mode],
+                   write_mbps,
+                   files_per_sec,
+                   compression_ratio,
+                   (space_saved > 0) ? space_saved : 0.0);
+            
+            unlink(container);
+        }
+        printf("\n");
+    }
+    
+    free(content);
+    return 0;
+}
+
+// Benchmark decompression performance
+static int benchmark_decompression(void) {
+    const char *container = "/tmp/benchmark_decomp.bfc";
+    const int num_files = 1000;
+    const size_t file_size = 32 * 1024; // 32KB files
+    
+    printf("\n=== Decompression Benchmark ===\n");
+    printf("Creating test container with %d files of %zu KB each\n", num_files, file_size / 1024);
+    
+    // First create a container with compressed files
+    char *content = malloc(file_size);
+    if (!content) {
+        printf("Failed to allocate content buffer\n");
+        return 1;
+    }
+    
+    generate_compressible_content(content, file_size);
+    
+    unlink(container);
+    
+    bfc_t *writer = NULL;
+    int result = bfc_create(container, 4096, 0, &writer);
+    if (result != BFC_OK) {
+        free(content);
+        return 1;
+    }
+    
+#ifdef BFC_WITH_ZSTD
+    bfc_set_compression(writer, BFC_COMP_ZSTD, 3);
+#else
+    bfc_set_compression(writer, BFC_COMP_NONE, 0);
+#endif
+    
+    // Add files to container
+    for (int i = 0; i < num_files; i++) {
+        char path[64];
+        snprintf(path, sizeof(path), "file_%05d.dat", i);
+        
+        FILE *temp = tmpfile();
+        if (!temp) break;
+        
+        fwrite(content, 1, file_size, temp);
+        rewind(temp);
+        
+        result = bfc_add_file(writer, path, temp, 0644, 0, NULL);
+        fclose(temp);
+        
+        if (result != BFC_OK) {
+            break;
+        }
+    }
+    
+    result = bfc_finish(writer);
+    bfc_close(writer);
+    
+    if (result != BFC_OK) {
+        printf("Failed to create test container\n");
+        free(content);
+        return 1;
+    }
+    
+    // Now benchmark reading/decompression
+    bfc_t *reader = NULL;
+    result = bfc_open(container, &reader);
+    if (result != BFC_OK) {
+        printf("Failed to open test container\n");
+        free(content);
+        unlink(container);
+        return 1;
+    }
+    
+    printf("Running decompression benchmark...\n");
+    
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    
+    // Read all files
+    char *read_buffer = malloc(file_size);
+    uint64_t total_read = 0;
+    int files_read = 0;
+    
+    for (int i = 0; i < num_files; i++) {
+        char path[64];
+        snprintf(path, sizeof(path), "file_%05d.dat", i);
+        
+        size_t bytes_read = bfc_read(reader, path, 0, read_buffer, file_size);
+        
+        if (bytes_read == file_size) {
+            total_read += bytes_read;
+            files_read++;
+        }
+    }
+    
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    
+    bfc_close_read(reader);
+    free(read_buffer);
+    
+    // Calculate metrics
+    double elapsed = benchmark_time_diff(&start, &end);
+    double read_mbps = benchmark_throughput_mbps(total_read, elapsed);
+    double files_per_sec = benchmark_ops_per_sec(files_read, elapsed);
+    
+    printf("Decompression Results:\n");
+    printf("  Files read: %d/%d\n", files_read, num_files);
+    printf("  Total data: "); 
+    
+    char data_str[32];
+    benchmark_format_bytes(total_read, data_str, sizeof(data_str));
+    printf("%s\n", data_str);
+    
+    printf("  Read throughput: %.1f MB/s\n", read_mbps);
+    printf("  Files per second: %.1f files/s\n", files_per_sec);
+    
+    free(content);
+    unlink(container);
+    return 0;
+}
+
+int main(void) {
+    printf("BFC Compression Benchmark Suite\n");
+    printf("===============================\n");
+    
+#ifdef BFC_WITH_ZSTD
+    printf("ZSTD compression: ENABLED\n");
+#else
+    printf("ZSTD compression: DISABLED\n");
+#endif
+    
+    int result = 0;
+    
+    result += benchmark_compression_levels();
+    result += benchmark_compression_scaling(); 
+    result += benchmark_decompression();
+    
+    printf("\nBenchmark completed %s\n", result == 0 ? "successfully" : "with errors");
+    return result;
+}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -29,6 +29,14 @@ add_executable(extract_example extract_example.c)
 target_link_libraries(extract_example bfc)
 target_include_directories(extract_example PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
+# Link ZSTD if enabled (needed for static library dependencies)
+if(BFC_WITH_ZSTD)
+    foreach(target create_example read_example extract_example)
+        target_link_libraries(${target} ${ZSTD_LIBRARIES})
+        target_link_directories(${target} PRIVATE ${ZSTD_LIBRARY_DIRS})
+    endforeach()
+endif()
+
 # Install examples
 install(TARGETS create_example read_example extract_example
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/examples)

--- a/include/bfc.h
+++ b/include/bfc.h
@@ -34,6 +34,13 @@ typedef enum {
   BFC_E_PERM = -7,
 } bfc_err_t;
 
+// Compression types
+#define BFC_COMP_NONE 0
+#define BFC_COMP_ZSTD 1
+
+// Feature flags
+#define BFC_FEATURE_ZSTD (1ULL << 0)
+
 typedef struct bfc bfc_t;
 
 typedef struct {
@@ -52,6 +59,12 @@ int bfc_create(const char* filename, uint32_t block_size, uint64_t features, bfc
 int bfc_add_file(bfc_t* w, const char* container_path, FILE* src, uint32_t mode, uint64_t mtime_ns,
                  uint32_t* out_crc);
 int bfc_add_dir(bfc_t* w, const char* container_dir, uint32_t mode, uint64_t mtime_ns);
+
+/* --- Compression Configuration --- */
+int bfc_set_compression(bfc_t* w, uint8_t comp_type, int level);
+int bfc_set_compression_threshold(bfc_t* w, size_t min_bytes);
+uint8_t bfc_get_compression(bfc_t* w);
+
 int bfc_finish(bfc_t* w); // writes index + footer, fsync
 void bfc_close(bfc_t* w); // closes handle, safe to call after finish
 

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -26,6 +26,12 @@ add_executable(bfc_cli ${BFC_CLI_SOURCES})
 
 target_link_libraries(bfc_cli bfc)
 
+# Link ZSTD if enabled (needed for static library dependencies)
+if(BFC_WITH_ZSTD)
+    target_link_libraries(bfc_cli ${ZSTD_LIBRARIES})
+    target_link_directories(bfc_cli PRIVATE ${ZSTD_LIBRARY_DIRS})
+endif()
+
 target_include_directories(bfc_cli PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src/lib

--- a/src/cli/cmd_info.c
+++ b/src/cli/cmd_info.c
@@ -279,8 +279,26 @@ static void show_entry_info(bfc_t* reader, const char* path) {
 
     double ratio = (entry.size > 0) ? (double) entry.obj_size / entry.size : 1.0;
 
+    // Show compression information
+    const char* comp_name;
+    switch (entry.comp) {
+    case BFC_COMP_NONE:
+      comp_name = "none";
+      break;
+    case BFC_COMP_ZSTD:
+      comp_name = "zstd";
+      break;
+    default:
+      comp_name = "unknown";
+      break;
+    }
+
+    printf("Compression: %s\n", comp_name);
     printf("Stored size: %s\n", stored_str);
     printf("Storage ratio: %.1f%%\n", ratio * 100.0);
+    if (entry.comp != BFC_COMP_NONE && entry.size > 0) {
+      printf("Compression ratio: %.1f%%\n", (1.0 - ratio) * 100.0);
+    }
     printf("CRC32C: 0x%08x\n", entry.crc32c);
     printf("Object offset: %" PRIu64 "\n", entry.obj_offset);
   }

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -18,6 +18,7 @@ set(BFC_LIB_SOURCES
     bfc_reader.c
     bfc_iter.c
     bfc_crc32c.c
+    bfc_compress.c
     bfc_os.c
     bfc_util.c
 )
@@ -25,6 +26,7 @@ set(BFC_LIB_SOURCES
 set(BFC_LIB_HEADERS
     bfc_format.h
     bfc_crc32c.h
+    bfc_compress.h
     bfc_os.h
     bfc_util.h
 )
@@ -60,6 +62,7 @@ foreach(target bfc bfc_shared)
         target_link_libraries(${target} ${ZSTD_LIBRARIES})
         target_compile_definitions(${target} PRIVATE BFC_WITH_ZSTD)
         target_include_directories(${target} PRIVATE ${ZSTD_INCLUDE_DIRS})
+        target_link_directories(${target} PRIVATE ${ZSTD_LIBRARY_DIRS})
     endif()
 endforeach()
 

--- a/src/lib/bfc_compress.c
+++ b/src/lib/bfc_compress.c
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2021 zombocoder (Taras Havryliak)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bfc_compress.h"
+#include "bfc.h"
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef BFC_WITH_ZSTD
+#include <zstd.h>
+#endif
+
+// Default compression level
+#define BFC_COMPRESS_DEFAULT_LEVEL 3
+
+// Minimum file size to consider compression (bytes)
+#define BFC_COMPRESS_MIN_SIZE 64
+
+// Compression context structure
+struct bfc_compress_ctx {
+  uint8_t type;
+  int level;
+#ifdef BFC_WITH_ZSTD
+  ZSTD_CStream* zstd_ctx;
+#endif
+};
+
+int bfc_compress_is_supported(uint8_t comp_type) {
+  switch (comp_type) {
+  case BFC_COMP_NONE:
+    return 1;
+#ifdef BFC_WITH_ZSTD
+  case BFC_COMP_ZSTD:
+    return 1;
+#endif
+  default:
+    return 0;
+  }
+}
+
+uint8_t bfc_compress_recommend(size_t size, const void* sample, size_t sample_size) {
+  // Don't compress very small files
+  if (size < BFC_COMPRESS_MIN_SIZE) {
+    return BFC_COMP_NONE;
+  }
+
+#ifndef BFC_WITH_ZSTD
+  (void) sample;      // Suppress unused parameter warning
+  (void) sample_size; // Suppress unused parameter warning
+#endif
+
+#ifdef BFC_WITH_ZSTD
+  // Analyze sample content if provided
+  if (sample && sample_size > 0) {
+    const uint8_t* data = (const uint8_t*) sample;
+    size_t zero_count = 0;
+    size_t repeat_count = 0;
+
+    // Count zeros and repeated bytes
+    for (size_t i = 0; i < sample_size; i++) {
+      if (data[i] == 0)
+        zero_count++;
+      if (i > 0 && data[i] == data[i - 1])
+        repeat_count++;
+    }
+
+    // If file has lots of zeros or repeated patterns, compression will help
+    double zero_ratio = (double) zero_count / sample_size;
+    double repeat_ratio = (double) repeat_count / sample_size;
+
+    if (zero_ratio > 0.1 || repeat_ratio > 0.2) {
+      return BFC_COMP_ZSTD;
+    }
+
+    // For text-like content (printable ASCII), compression usually helps
+    size_t printable_count = 0;
+    for (size_t i = 0; i < sample_size; i++) {
+      if ((data[i] >= 32 && data[i] <= 126) || data[i] == '\n' || data[i] == '\r' ||
+          data[i] == '\t') {
+        printable_count++;
+      }
+    }
+
+    if ((double) printable_count / sample_size > 0.8) {
+      return BFC_COMP_ZSTD;
+    }
+  }
+
+  // For larger files, default to compression
+  if (size > 1024) {
+    return BFC_COMP_ZSTD;
+  }
+#endif
+
+  return BFC_COMP_NONE;
+}
+
+bfc_compress_result_t bfc_compress_data(uint8_t comp_type, const void* input, size_t input_size,
+                                        int level) {
+  bfc_compress_result_t result = {0};
+
+  if (!input || input_size == 0) {
+    result.error = BFC_E_INVAL;
+    return result;
+  }
+
+  if (!bfc_compress_is_supported(comp_type)) {
+    result.error = BFC_E_INVAL;
+    return result;
+  }
+
+#ifndef BFC_WITH_ZSTD
+  (void) level; // Suppress unused parameter warning when ZSTD not available
+#endif
+
+  switch (comp_type) {
+  case BFC_COMP_NONE:
+    // No compression - just copy data
+    result.data = malloc(input_size);
+    if (!result.data) {
+      result.error = BFC_E_IO;
+      return result;
+    }
+    memcpy(result.data, input, input_size);
+    result.compressed_size = input_size;
+    result.original_size = input_size;
+    result.error = BFC_OK;
+    break;
+
+#ifdef BFC_WITH_ZSTD
+  case BFC_COMP_ZSTD: {
+    if (level <= 0)
+      level = BFC_COMPRESS_DEFAULT_LEVEL;
+    if (level > ZSTD_maxCLevel())
+      level = ZSTD_maxCLevel();
+
+    size_t max_compressed_size = ZSTD_compressBound(input_size);
+    result.data = malloc(max_compressed_size);
+    if (!result.data) {
+      result.error = BFC_E_IO;
+      return result;
+    }
+
+    size_t compressed_size =
+        ZSTD_compress(result.data, max_compressed_size, input, input_size, level);
+
+    if (ZSTD_isError(compressed_size)) {
+      free(result.data);
+      result.data = NULL;
+      result.error = BFC_E_IO;
+      return result;
+    }
+
+    // Shrink buffer to actual size
+    void* new_data = realloc(result.data, compressed_size);
+    if (new_data || compressed_size == 0) {
+      result.data = new_data;
+    }
+
+    result.compressed_size = compressed_size;
+    result.original_size = input_size;
+    result.error = BFC_OK;
+  } break;
+#endif
+
+  default:
+    result.error = BFC_E_INVAL;
+    break;
+  }
+
+  return result;
+}
+
+bfc_decompress_result_t bfc_decompress_data(uint8_t comp_type, const void* input, size_t input_size,
+                                            size_t expected_size) {
+  bfc_decompress_result_t result = {0};
+
+  if (!input || input_size == 0) {
+    result.error = BFC_E_INVAL;
+    return result;
+  }
+
+  if (!bfc_compress_is_supported(comp_type)) {
+    result.error = BFC_E_INVAL;
+    return result;
+  }
+
+#ifndef BFC_WITH_ZSTD
+  (void) expected_size; // Suppress unused parameter warning when ZSTD not available
+#endif
+
+  switch (comp_type) {
+  case BFC_COMP_NONE:
+    // No decompression - just copy data
+    result.data = malloc(input_size);
+    if (!result.data) {
+      result.error = BFC_E_IO;
+      return result;
+    }
+    memcpy(result.data, input, input_size);
+    result.decompressed_size = input_size;
+    result.error = BFC_OK;
+    break;
+
+#ifdef BFC_WITH_ZSTD
+  case BFC_COMP_ZSTD: {
+    // Use expected size if provided, otherwise get from compressed data
+    size_t decompressed_size = expected_size;
+    if (decompressed_size == 0) {
+      decompressed_size = ZSTD_getFrameContentSize(input, input_size);
+      if (decompressed_size == ZSTD_CONTENTSIZE_ERROR ||
+          decompressed_size == ZSTD_CONTENTSIZE_UNKNOWN) {
+        result.error = BFC_E_CRC;
+        return result;
+      }
+    }
+
+    result.data = malloc(decompressed_size);
+    if (!result.data) {
+      result.error = BFC_E_IO;
+      return result;
+    }
+
+    size_t actual_size = ZSTD_decompress(result.data, decompressed_size, input, input_size);
+
+    if (ZSTD_isError(actual_size)) {
+      free(result.data);
+      result.data = NULL;
+      result.error = BFC_E_CRC;
+      return result;
+    }
+
+    // Verify size matches expectation
+    if (expected_size > 0 && actual_size != expected_size) {
+      free(result.data);
+      result.data = NULL;
+      result.error = BFC_E_CRC;
+      return result;
+    }
+
+    result.decompressed_size = actual_size;
+    result.error = BFC_OK;
+  } break;
+#endif
+
+  default:
+    result.error = BFC_E_INVAL;
+    break;
+  }
+
+  return result;
+}
+
+bfc_compress_ctx_t* bfc_compress_ctx_create(uint8_t comp_type, int level) {
+  if (!bfc_compress_is_supported(comp_type)) {
+    return NULL;
+  }
+
+  bfc_compress_ctx_t* ctx = calloc(1, sizeof(*ctx));
+  if (!ctx)
+    return NULL;
+
+  ctx->type = comp_type;
+  ctx->level = level > 0 ? level : BFC_COMPRESS_DEFAULT_LEVEL;
+
+#ifdef BFC_WITH_ZSTD
+  if (comp_type == BFC_COMP_ZSTD) {
+    ctx->zstd_ctx = ZSTD_createCStream();
+    if (!ctx->zstd_ctx) {
+      free(ctx);
+      return NULL;
+    }
+
+    size_t ret = ZSTD_initCStream(ctx->zstd_ctx, ctx->level);
+    if (ZSTD_isError(ret)) {
+      ZSTD_freeCStream(ctx->zstd_ctx);
+      free(ctx);
+      return NULL;
+    }
+  }
+#endif
+
+  return ctx;
+}
+
+int bfc_compress_ctx_process(bfc_compress_ctx_t* ctx, const void* input, size_t input_size,
+                             void* output, size_t output_size, size_t* bytes_consumed,
+                             size_t* bytes_produced, int flush_mode) {
+  if (!ctx || !bytes_consumed || !bytes_produced) {
+    return BFC_E_INVAL;
+  }
+
+  *bytes_consumed = 0;
+  *bytes_produced = 0;
+
+#ifndef BFC_WITH_ZSTD
+  (void) flush_mode; // Suppress unused parameter warning when ZSTD not available
+#endif
+
+  switch (ctx->type) {
+  case BFC_COMP_NONE:
+    // No compression - just copy data
+    {
+      size_t copy_size = input_size < output_size ? input_size : output_size;
+      if (copy_size > 0 && input && output) {
+        memcpy(output, input, copy_size);
+      }
+      *bytes_consumed = copy_size;
+      *bytes_produced = copy_size;
+      return BFC_OK;
+    }
+
+#ifdef BFC_WITH_ZSTD
+  case BFC_COMP_ZSTD: {
+    ZSTD_inBuffer inbuf = {input, input_size, 0};
+    ZSTD_outBuffer outbuf = {output, output_size, 0};
+
+    ZSTD_EndDirective directive;
+    switch (flush_mode) {
+    case 0:
+      directive = ZSTD_e_continue;
+      break;
+    case 1:
+      directive = ZSTD_e_flush;
+      break;
+    case 2:
+      directive = ZSTD_e_end;
+      break;
+    default:
+      return BFC_E_INVAL;
+    }
+
+    size_t ret = ZSTD_compressStream2(ctx->zstd_ctx, &outbuf, &inbuf, directive);
+    if (ZSTD_isError(ret)) {
+      return BFC_E_IO;
+    }
+
+    *bytes_consumed = inbuf.pos;
+    *bytes_produced = outbuf.pos;
+    return BFC_OK;
+  }
+#endif
+
+  default:
+    return BFC_E_INVAL;
+  }
+}
+
+void bfc_compress_ctx_destroy(bfc_compress_ctx_t* ctx) {
+  if (!ctx)
+    return;
+
+#ifdef BFC_WITH_ZSTD
+  if (ctx->zstd_ctx) {
+    ZSTD_freeCStream(ctx->zstd_ctx);
+  }
+#endif
+
+  free(ctx);
+}
+
+const char* bfc_compress_name(uint8_t comp_type) {
+  switch (comp_type) {
+  case BFC_COMP_NONE:
+    return "none";
+  case BFC_COMP_ZSTD:
+    return "zstd";
+  default:
+    return "unknown";
+  }
+}
+
+double bfc_compress_ratio(size_t original_size, size_t compressed_size) {
+  if (original_size == 0)
+    return 0.0;
+  return (double) compressed_size * 100.0 / original_size;
+}

--- a/src/lib/bfc_compress.h
+++ b/src/lib/bfc_compress.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021 zombocoder (Taras Havryliak)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "bfc_format.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Compression context for streaming operations
+typedef struct bfc_compress_ctx bfc_compress_ctx_t;
+
+// Compression result structure
+typedef struct {
+  void* data; // Compressed data (caller must free)
+  size_t compressed_size;
+  size_t original_size;
+  int error; // BFC_OK on success
+} bfc_compress_result_t;
+
+// Decompression result structure
+typedef struct {
+  void* data; // Decompressed data (caller must free)
+  size_t decompressed_size;
+  int error; // BFC_OK on success
+} bfc_decompress_result_t;
+
+/**
+ * Check if compression type is supported
+ * @param comp_type Compression type (BFC_COMP_*)
+ * @return 1 if supported, 0 if not
+ */
+int bfc_compress_is_supported(uint8_t comp_type);
+
+/**
+ * Get recommended compression type based on file size and content
+ * @param size File size in bytes
+ * @param sample Sample of file content (optional, can be NULL)
+ * @param sample_size Size of sample
+ * @return Recommended compression type
+ */
+uint8_t bfc_compress_recommend(size_t size, const void* sample, size_t sample_size);
+
+/**
+ * Compress data using specified algorithm
+ * @param comp_type Compression type (BFC_COMP_*)
+ * @param input Input data
+ * @param input_size Input data size
+ * @param level Compression level (0=default, 1-22 for ZSTD)
+ * @return Compression result (caller must free result.data)
+ */
+bfc_compress_result_t bfc_compress_data(uint8_t comp_type, const void* input, size_t input_size,
+                                        int level);
+
+/**
+ * Decompress data using specified algorithm
+ * @param comp_type Compression type (BFC_COMP_*)
+ * @param input Compressed data
+ * @param input_size Compressed data size
+ * @param expected_size Expected decompressed size (for validation)
+ * @return Decompression result (caller must free result.data)
+ */
+bfc_decompress_result_t bfc_decompress_data(uint8_t comp_type, const void* input, size_t input_size,
+                                            size_t expected_size);
+
+/**
+ * Create streaming compression context
+ * @param comp_type Compression type
+ * @param level Compression level
+ * @return Context pointer or NULL on error
+ */
+bfc_compress_ctx_t* bfc_compress_ctx_create(uint8_t comp_type, int level);
+
+/**
+ * Process data through streaming compression
+ * @param ctx Compression context
+ * @param input Input data
+ * @param input_size Input size
+ * @param output Output buffer
+ * @param output_size Output buffer size
+ * @param bytes_consumed Bytes consumed from input
+ * @param bytes_produced Bytes written to output
+ * @param flush_mode 0=continue, 1=flush, 2=finish
+ * @return BFC_OK on success
+ */
+int bfc_compress_ctx_process(bfc_compress_ctx_t* ctx, const void* input, size_t input_size,
+                             void* output, size_t output_size, size_t* bytes_consumed,
+                             size_t* bytes_produced, int flush_mode);
+
+/**
+ * Destroy compression context
+ * @param ctx Context to destroy
+ */
+void bfc_compress_ctx_destroy(bfc_compress_ctx_t* ctx);
+
+/**
+ * Get compression algorithm name
+ * @param comp_type Compression type
+ * @return Algorithm name or "unknown"
+ */
+const char* bfc_compress_name(uint8_t comp_type);
+
+/**
+ * Get compression statistics
+ * @param comp_type Compression type
+ * @param original_size Original data size
+ * @param compressed_size Compressed data size
+ * @return Compression ratio as percentage (0-100)
+ */
+double bfc_compress_ratio(size_t original_size, size_t compressed_size);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -22,12 +22,20 @@ set(UNIT_TEST_SOURCES
     test_reader.c
     test_util.c
     test_os.c
+    test_compress.c
     test_main.c
 )
 
 add_executable(unit_tests ${UNIT_TEST_SOURCES})
 
 target_link_libraries(unit_tests bfc)
+
+# Link ZSTD if enabled (needed for static library dependencies)
+if(BFC_WITH_ZSTD)
+    target_link_libraries(unit_tests ${ZSTD_LIBRARIES})
+    target_link_directories(unit_tests PRIVATE ${ZSTD_LIBRARY_DIRS})
+    target_compile_definitions(unit_tests PRIVATE BFC_WITH_ZSTD)
+endif()
 
 target_include_directories(unit_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/include
@@ -42,4 +50,5 @@ add_test(NAME unit_writer COMMAND unit_tests writer)
 add_test(NAME unit_reader COMMAND unit_tests reader)
 add_test(NAME unit_util COMMAND unit_tests util)
 add_test(NAME unit_os COMMAND unit_tests os)
+add_test(NAME unit_compress COMMAND unit_tests compress)
 add_test(NAME unit_all COMMAND unit_tests)

--- a/tests/unit/test_compress.c
+++ b/tests/unit/test_compress.c
@@ -1,0 +1,381 @@
+/*
+ * Copyright 2021 zombocoder (Taras Havryliak)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bfc_compress.h"
+#include <assert.h>
+#include <bfc.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+// Test basic compression support detection
+static int test_compression_support(void) {
+  // BFC_COMP_NONE should always be supported
+  assert(bfc_compress_is_supported(BFC_COMP_NONE) == 1);
+
+  // Invalid compression type should not be supported
+  assert(bfc_compress_is_supported(255) == 0);
+
+#ifdef BFC_WITH_ZSTD
+  // ZSTD should be supported when built with it
+  assert(bfc_compress_is_supported(BFC_COMP_ZSTD) == 1);
+#else
+  // ZSTD should not be supported when not built with it
+  assert(bfc_compress_is_supported(BFC_COMP_ZSTD) == 0);
+#endif
+
+  return 0;
+}
+
+// Test compression recommendation logic
+static int test_compression_recommend(void) {
+  // Very small files should not be compressed
+  uint8_t comp = bfc_compress_recommend(32, NULL, 0);
+  assert(comp == BFC_COMP_NONE);
+
+  // Sample with lots of zeros should be compressed (if ZSTD available)
+  char zero_data[1024];
+  memset(zero_data, 0, sizeof(zero_data));
+  comp = bfc_compress_recommend(sizeof(zero_data), zero_data, sizeof(zero_data));
+#ifdef BFC_WITH_ZSTD
+  assert(comp == BFC_COMP_ZSTD);
+#else
+  assert(comp == BFC_COMP_NONE);
+#endif
+
+  // Sample with repeated patterns should be compressed (if ZSTD available)
+  char repeat_data[1024];
+  for (size_t i = 0; i < sizeof(repeat_data); i++) {
+    repeat_data[i] = 'A';
+  }
+  comp = bfc_compress_recommend(sizeof(repeat_data), repeat_data, sizeof(repeat_data));
+#ifdef BFC_WITH_ZSTD
+  assert(comp == BFC_COMP_ZSTD);
+#else
+  assert(comp == BFC_COMP_NONE);
+#endif
+
+  // Text-like content should be compressed (if ZSTD available)
+  const char* text_data =
+      "Hello world! This is a test string with repeating patterns and text content.";
+  comp = bfc_compress_recommend(strlen(text_data), text_data, strlen(text_data));
+#ifdef BFC_WITH_ZSTD
+  assert(comp == BFC_COMP_ZSTD);
+#else
+  assert(comp == BFC_COMP_NONE);
+#endif
+
+  return 0;
+}
+
+// Test basic data compression and decompression
+static int test_compress_decompress_data(void) {
+  const char* test_data = "Hello, world! This is test data for compression. "
+                          "It contains repeated words and patterns that should compress well. "
+                          "Hello, world! This is test data for compression.";
+  size_t data_size = strlen(test_data);
+
+  // Test with no compression
+  bfc_compress_result_t comp_result = bfc_compress_data(BFC_COMP_NONE, test_data, data_size, 0);
+  assert(comp_result.error == BFC_OK);
+  assert(comp_result.data != NULL);
+  assert(comp_result.compressed_size == data_size);
+  assert(comp_result.original_size == data_size);
+  assert(memcmp(comp_result.data, test_data, data_size) == 0);
+
+  // Test decompression
+  bfc_decompress_result_t decomp_result =
+      bfc_decompress_data(BFC_COMP_NONE, comp_result.data, comp_result.compressed_size, data_size);
+  assert(decomp_result.error == BFC_OK);
+  assert(decomp_result.data != NULL);
+  assert(decomp_result.decompressed_size == data_size);
+  assert(memcmp(decomp_result.data, test_data, data_size) == 0);
+
+  free(comp_result.data);
+  free(decomp_result.data);
+
+#ifdef BFC_WITH_ZSTD
+  // Test ZSTD compression
+  comp_result = bfc_compress_data(BFC_COMP_ZSTD, test_data, data_size, 3);
+  assert(comp_result.error == BFC_OK);
+  assert(comp_result.data != NULL);
+  assert(comp_result.original_size == data_size);
+  // Compressed size should be smaller for this repetitive text
+  assert(comp_result.compressed_size < data_size);
+
+  // Test ZSTD decompression
+  decomp_result =
+      bfc_decompress_data(BFC_COMP_ZSTD, comp_result.data, comp_result.compressed_size, data_size);
+  assert(decomp_result.error == BFC_OK);
+  assert(decomp_result.data != NULL);
+  assert(decomp_result.decompressed_size == data_size);
+  assert(memcmp(decomp_result.data, test_data, data_size) == 0);
+
+  free(comp_result.data);
+  free(decomp_result.data);
+#endif
+
+  return 0;
+}
+
+// Test error handling in compression functions
+static int test_compress_error_handling(void) {
+  const char* test_data = "test data";
+
+  // Test invalid parameters
+  bfc_compress_result_t result = bfc_compress_data(BFC_COMP_NONE, NULL, 10, 0);
+  assert(result.error == BFC_E_INVAL);
+  assert(result.data == NULL);
+
+  result = bfc_compress_data(BFC_COMP_NONE, test_data, 0, 0);
+  assert(result.error == BFC_E_INVAL);
+  assert(result.data == NULL);
+
+  result = bfc_compress_data(255, test_data, 10, 0); // Invalid compression type
+  assert(result.error == BFC_E_INVAL);
+  assert(result.data == NULL);
+
+  // Test decompression error handling
+  bfc_decompress_result_t decomp_result = bfc_decompress_data(BFC_COMP_NONE, NULL, 10, 0);
+  assert(decomp_result.error == BFC_E_INVAL);
+  assert(decomp_result.data == NULL);
+
+  decomp_result = bfc_decompress_data(BFC_COMP_NONE, test_data, 0, 0);
+  assert(decomp_result.error == BFC_E_INVAL);
+  assert(decomp_result.data == NULL);
+
+  decomp_result = bfc_decompress_data(255, test_data, 10, 0); // Invalid compression type
+  assert(decomp_result.error == BFC_E_INVAL);
+  assert(decomp_result.data == NULL);
+
+  return 0;
+}
+
+// Test compression context creation and management
+static int test_compression_context(void) {
+  // Test creating context for no compression
+  bfc_compress_ctx_t* ctx = bfc_compress_ctx_create(BFC_COMP_NONE, 0);
+  assert(ctx != NULL);
+
+  // Test basic streaming operation
+  const char* input = "test input data";
+  char output[1024];
+  size_t bytes_consumed, bytes_produced;
+
+  int result = bfc_compress_ctx_process(ctx, input, strlen(input), output, sizeof(output),
+                                        &bytes_consumed, &bytes_produced, 0);
+  assert(result == BFC_OK);
+  assert(bytes_consumed == strlen(input));
+  assert(bytes_produced == strlen(input));
+  assert(memcmp(output, input, strlen(input)) == 0);
+
+  bfc_compress_ctx_destroy(ctx);
+
+  // Test invalid context creation
+  ctx = bfc_compress_ctx_create(255, 0); // Invalid compression type
+  assert(ctx == NULL);
+
+#ifdef BFC_WITH_ZSTD
+  // Test ZSTD context creation
+  ctx = bfc_compress_ctx_create(BFC_COMP_ZSTD, 3);
+  assert(ctx != NULL);
+  bfc_compress_ctx_destroy(ctx);
+#endif
+
+  return 0;
+}
+
+// Test compression utility functions
+static int test_compression_utilities(void) {
+  // Test compression type names
+  assert(strcmp(bfc_compress_name(BFC_COMP_NONE), "none") == 0);
+  assert(strcmp(bfc_compress_name(BFC_COMP_ZSTD), "zstd") == 0);
+  assert(strcmp(bfc_compress_name(255), "unknown") == 0);
+
+  // Test compression ratio calculation
+  assert(bfc_compress_ratio(0, 0) == 0.0);
+  assert(bfc_compress_ratio(100, 50) == 50.0);
+  assert(bfc_compress_ratio(100, 100) == 100.0);
+  assert(bfc_compress_ratio(100, 150) == 150.0);
+
+  return 0;
+}
+
+// Test BFC writer compression settings
+static int test_writer_compression_settings(void) {
+  const char* filename = "/tmp/test_compression_writer.bfc";
+  unlink(filename);
+
+  bfc_t* writer = NULL;
+  int result = bfc_create(filename, 4096, 0, &writer);
+  assert(result == BFC_OK);
+  assert(writer != NULL);
+
+  // Test setting compression
+  result = bfc_set_compression(writer, BFC_COMP_NONE, 0);
+  assert(result == BFC_OK);
+  assert(bfc_get_compression(writer) == BFC_COMP_NONE);
+
+  // Test setting compression threshold
+  result = bfc_set_compression_threshold(writer, 1024);
+  assert(result == BFC_OK);
+
+#ifdef BFC_WITH_ZSTD
+  // Test ZSTD compression setting
+  result = bfc_set_compression(writer, BFC_COMP_ZSTD, 5);
+  assert(result == BFC_OK);
+  assert(bfc_get_compression(writer) == BFC_COMP_ZSTD);
+#endif
+
+  // Test invalid compression type
+  result = bfc_set_compression(writer, 255, 0);
+  assert(result == BFC_E_INVAL);
+
+  bfc_close(writer);
+  unlink(filename);
+
+  return 0;
+}
+
+// Test end-to-end compression with BFC container
+static int test_end_to_end_compression(void) {
+  const char* container_filename = "/tmp/test_e2e_compression.bfc";
+  const char* test_filename = "/tmp/test_e2e_input.txt";
+  const char* extract_filename = "/tmp/test_e2e_output.txt";
+
+  // Clean up any existing files
+  unlink(container_filename);
+  unlink(test_filename);
+  unlink(extract_filename);
+
+  // Create test input file with compressible content
+  FILE* input_file = fopen(test_filename, "w");
+  assert(input_file != NULL);
+
+  const char* repeating_content =
+      "This is a test line that repeats multiple times for compression testing.\n";
+  for (int i = 0; i < 100; i++) { // Create 100 lines of repeated content
+    fputs(repeating_content, input_file);
+  }
+  fclose(input_file);
+
+  // Create BFC container with compression
+  bfc_t* writer = NULL;
+  int result = bfc_create(container_filename, 4096, 0, &writer);
+  assert(result == BFC_OK);
+
+  // Set compression (use NONE if ZSTD not available)
+#ifdef BFC_WITH_ZSTD
+  result = bfc_set_compression(writer, BFC_COMP_ZSTD, 3);
+#else
+  result = bfc_set_compression(writer, BFC_COMP_NONE, 0);
+#endif
+  assert(result == BFC_OK);
+
+  // Add the test file
+  FILE* test_file = fopen(test_filename, "rb");
+  assert(test_file != NULL);
+
+  result = bfc_add_file(writer, "test_file.txt", test_file, 0644, 0, NULL);
+  assert(result == BFC_OK);
+  fclose(test_file);
+
+  result = bfc_finish(writer);
+  assert(result == BFC_OK);
+  bfc_close(writer);
+
+  // Read back the file and verify compression info
+  bfc_t* reader = NULL;
+  result = bfc_open(container_filename, &reader);
+  assert(result == BFC_OK);
+
+  bfc_entry_t entry;
+  result = bfc_stat(reader, "test_file.txt", &entry);
+  assert(result == BFC_OK);
+
+  // Verify compression type is set correctly
+#ifdef BFC_WITH_ZSTD
+  assert(entry.comp == BFC_COMP_ZSTD);
+  // For repetitive content, compressed size should be much smaller
+  assert(entry.obj_size < entry.size / 2);
+#else
+  assert(entry.comp == BFC_COMP_NONE);
+  // Without compression, stored size should be the same (plus some overhead)
+  assert(entry.obj_size >= entry.size);
+#endif
+
+  // Extract and verify content
+  int out_fd = open(extract_filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+  assert(out_fd >= 0);
+
+  result = bfc_extract_to_fd(reader, "test_file.txt", out_fd);
+  assert(result == BFC_OK);
+  close(out_fd);
+  bfc_close_read(reader);
+
+  // Compare original and extracted files
+  FILE* orig = fopen(test_filename, "rb");
+  FILE* extracted = fopen(extract_filename, "rb");
+  assert(orig != NULL);
+  assert(extracted != NULL);
+
+  // Compare file sizes
+  fseek(orig, 0, SEEK_END);
+  long orig_size = ftell(orig);
+  fseek(extracted, 0, SEEK_END);
+  long extracted_size = ftell(extracted);
+  assert(orig_size == extracted_size);
+
+  // Compare content
+  rewind(orig);
+  rewind(extracted);
+
+  char orig_buf[4096], extracted_buf[4096];
+  size_t orig_read, extracted_read;
+
+  while ((orig_read = fread(orig_buf, 1, sizeof(orig_buf), orig)) > 0) {
+    extracted_read = fread(extracted_buf, 1, sizeof(extracted_buf), extracted);
+    assert(orig_read == extracted_read);
+    assert(memcmp(orig_buf, extracted_buf, orig_read) == 0);
+  }
+
+  fclose(orig);
+  fclose(extracted);
+
+  // Clean up
+  unlink(container_filename);
+  unlink(test_filename);
+  unlink(extract_filename);
+
+  return 0;
+}
+
+int test_compress(void) {
+  int result = 0;
+
+  result += test_compression_support();
+  result += test_compression_recommend();
+  result += test_compress_decompress_data();
+  result += test_compress_error_handling();
+  result += test_compression_context();
+  result += test_compression_utilities();
+  result += test_writer_compression_settings();
+  result += test_end_to_end_compression();
+
+  return result;
+}

--- a/tests/unit/test_main.c
+++ b/tests/unit/test_main.c
@@ -26,6 +26,7 @@ int test_writer(void);
 int test_reader(void);
 int test_util(void);
 int test_os(void);
+int test_compress(void);
 
 typedef struct {
   const char* name;
@@ -33,8 +34,9 @@ typedef struct {
 } test_case_t;
 
 static test_case_t tests[] = {
-    {"format", test_format}, {"crc32c", test_crc32c}, {"path", test_path}, {"writer", test_writer},
-    {"reader", test_reader}, {"util", test_util},     {"os", test_os},     {NULL, NULL}};
+    {"format", test_format}, {"crc32c", test_crc32c},     {"path", test_path},
+    {"writer", test_writer}, {"reader", test_reader},     {"util", test_util},
+    {"os", test_os},         {"compress", test_compress}, {NULL, NULL}};
 
 static int run_test(const char* name, int (*func)(void)) {
   printf("Running test: %s... ", name);


### PR DESCRIPTION
This pull request introduces comprehensive support for ZSTD compression in the BFC project, including build system integration, CI/CD pipeline updates, new documentation, and benchmarking tools. The changes ensure that ZSTD compression can be enabled or disabled via build flags, is tested across platforms, and is documented for users and contributors.

**Build System and CI/CD Integration:**
- Added `libzstd-dev` as a dependency in all relevant CI/CD jobs and workflows, ensuring ZSTD is available for builds and tests on both Linux and macOS. The CMake configuration now enables ZSTD support with the `-DBFC_WITH_ZSTD=ON` flag, and emits a status message when enabled. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL34-R39) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL52-R53) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR80-R89) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL90-R110) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL134-R155) [[6]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL225-R243) [[7]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL266-R285) [[8]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L43-R52) [[9]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L63-R64) [[10]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR57)

**Documentation Updates:**
- Updated `README.md` to describe ZSTD compression features, usage examples, and compression behavior in BFC, including command-line options and expected results. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R101-R134)

**Benchmarking and Testing:**
- Introduced a new compression benchmark (`benchmark_compress`) in the benchmarks suite, with documentation and CMake integration. The benchmark tests compression and decompression performance, and is included in the all-benchmarks runner. [[1]](diffhunk://#diff-0e89c6321b6a3a2bbd8586415659571fb5a7cd0af6aefe415a6a07c277bad14bR38-R65) [[2]](diffhunk://#diff-0e89c6321b6a3a2bbd8586415659571fb5a7cd0af6aefe415a6a07c277bad14bR74) [[3]](diffhunk://#diff-0e89c6321b6a3a2bbd8586415659571fb5a7cd0af6aefe415a6a07c277bad14bR100-R108) [[4]](diffhunk://#diff-576c27794bae284efc278336a16d0649aaf599973a64d4b65dc67bc99bb7f000L71-R108) [[5]](diffhunk://#diff-576c27794bae284efc278336a16d0649aaf599973a64d4b65dc67bc99bb7f000R122-R124) [[6]](diffhunk://#diff-576c27794bae284efc278336a16d0649aaf599973a64d4b65dc67bc99bb7f000R135)

**Build and Development Tools:**
- Added a new `Makefile` providing convenient targets for building, testing, formatting, code coverage, and static analysis, with ZSTD enabled by default.

**Example and Library Linking:**
- Updated example programs and benchmarks to link against ZSTD libraries when compression support is enabled, ensuring correct static/dynamic linkage.

These changes collectively make ZSTD compression a first-class, well-documented, and well-tested feature of the BFC project.