### PR TITLE
Reorder directory change and container opening in extract command for…

### DIFF
--- a/src/cli/cmd_extract.c
+++ b/src/cli/cmd_extract.c
@@ -382,16 +382,7 @@ int cmd_extract(int argc, char* argv[]) {
     return (result > 0) ? 0 : 1;
   }
 
-  // Change to output directory if specified
-  if (opts.output_dir) {
-    print_verbose("Changing to directory: %s", opts.output_dir);
-    if (chdir(opts.output_dir) != 0) {
-      print_error("Cannot change to directory '%s': %s", opts.output_dir, strerror(errno));
-      return 1;
-    }
-  }
-
-  // Open container for reading
+  // Open container for reading BEFORE changing directories
   print_verbose("Opening container: %s", opts.container_file);
 
   bfc_t* reader = NULL;
@@ -399,6 +390,16 @@ int cmd_extract(int argc, char* argv[]) {
   if (result != BFC_OK) {
     print_error("Failed to open container '%s': %s", opts.container_file, bfc_error_string(result));
     return 1;
+  }
+
+  // Change to output directory if specified (after opening container)
+  if (opts.output_dir) {
+    print_verbose("Changing to directory: %s", opts.output_dir);
+    if (chdir(opts.output_dir) != 0) {
+      print_error("Cannot change to directory '%s': %s", opts.output_dir, strerror(errno));
+      bfc_close_read(reader);
+      return 1;
+    }
   }
 
   // Configure encryption if needed


### PR DESCRIPTION
This pull request significantly improves the usability and clarity of the `bfc` CLI tool by expanding and reorganizing the documentation in `README.md` and correcting the order of operations in the `extract` command implementation. The changes provide detailed command references, better usage examples, and ensure correct behavior when extracting files to a specific directory.

Documentation improvements:

* Expanded the `README.md` with detailed sections for each CLI command, including syntax, options, and practical usage examples for `create`, `list`, `extract`, `info`, and `verify` commands. This also includes a new CLI reference section with a quick summary table and a complete option reference for all commands. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R99-R148) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R232-R343) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R402-R482)

Code correctness and usability:

* In `src/cli/cmd_extract.c`, fixed the order of operations so that the container is opened before changing the working directory. This prevents issues when the output directory does not exist or is inaccessible, ensuring the container can always be found and closed properly. [[1]](diffhunk://#diff-adc6a8359682648d57bbf88c56f45bb2d5e812a79d2b96ad99fe877c7f488f87L385-R385) [[2]](diffhunk://#diff-adc6a8359682648d57bbf88c56f45bb2d5e812a79d2b96ad99fe877c7f488f87R395-R404)