### PR TITLE
Add comprehensive symlink support to BFC containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,75 @@ jobs:
           cd ..
           rm -rf extract_test
 
+          # Test symlink functionality
+          echo "Testing symlink functionality..."
+          
+          # Create test data with symlinks
+          mkdir -p test_symlinks
+          cd test_symlinks
+          echo "Target file content" > target.txt
+          mkdir subdir
+          echo "Nested target" > subdir/nested.txt
+          
+          # Create various types of symlinks
+          ln -sf target.txt simple_link.txt
+          ln -sf subdir/nested.txt relative_link.txt
+          ln -sf /tmp/absolute_target absolute_link.txt
+          ln -sf nonexistent_file broken_link.txt
+          ln -sf subdir dir_link
+          cd ..
+
+          # Test container creation with symlinks
+          ./build/bin/bfc create test_symlinks.bfc test_symlinks/
+          echo "Container with symlinks created"
+
+          # Test symlink listing - verify 'l' prefix appears
+          ./build/bin/bfc list -l test_symlinks.bfc | grep "lrwxr-xr-x.*simple_link.txt" && echo "Simple symlink listed correctly" || echo "Simple symlink listing failed"
+          ./build/bin/bfc list -l test_symlinks.bfc | grep "lrwxr-xr-x.*absolute_link.txt" && echo "Absolute symlink listed correctly" || echo "Absolute symlink listing failed"
+          
+          # Test symlink counting in container info
+          ./build/bin/bfc info test_symlinks.bfc | grep "Symlinks:" && echo "Symlinks counted in container info" || echo "Symlink counting failed"
+          
+          # Test symlink-specific info
+          ./build/bin/bfc info test_symlinks.bfc simple_link.txt | grep "Type: Symlink" && echo "Symlink type displayed correctly" || echo "Symlink type display failed"
+
+          # Test symlink extraction
+          mkdir -p extract_symlinks
+          cd extract_symlinks
+          ../build/bin/bfc extract ../test_symlinks.bfc
+          
+          # Verify symlinks were extracted correctly
+          [ -L simple_link.txt ] && echo "Simple symlink extracted as symlink" || echo "Simple symlink not extracted as symlink"
+          [ -L broken_link.txt ] && echo "Broken symlink extracted as symlink" || echo "Broken symlink not extracted as symlink"
+          
+          # Verify symlink targets
+          if [ -L simple_link.txt ]; then
+            TARGET=$(readlink simple_link.txt)
+            [ "$TARGET" = "target.txt" ] && echo "Simple symlink target correct" || echo "Simple symlink target incorrect: $TARGET"
+          fi
+          
+          if [ -L absolute_link.txt ]; then
+            TARGET=$(readlink absolute_link.txt)
+            [ "$TARGET" = "/tmp/absolute_target" ] && echo "Absolute symlink target correct" || echo "Absolute symlink target incorrect: $TARGET"
+          fi
+          
+          cd ..
+          rm -rf extract_symlinks
+          
+          # Test symlinks with compression and encryption
+          ./build/bin/bfc create -c zstd -e testpass symlinks_comp_enc.bfc test_symlinks/simple_link.txt test_symlinks/absolute_link.txt
+          echo "Symlinks work with compression and encryption"
+          
+          mkdir -p extract_comp_enc
+          cd extract_comp_enc
+          ../build/bin/bfc extract -p testpass ../symlinks_comp_enc.bfc
+          [ -L simple_link.txt ] && echo "Compressed+encrypted symlink extracted correctly" || echo "Compressed+encrypted symlink extraction failed"
+          cd ..
+          rm -rf extract_comp_enc
+          
+          # Clean up symlink test files
+          rm -rf test_symlinks test_symlinks.bfc symlinks_comp_enc.bfc
+
           # Test encryption functionality
           echo "Testing encryption features..."
           ./build/bin/bfc create -e testpassword123 test_encrypted.bfc test_data/

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ configure:
 	@echo "Configuring CMake build..."
 	cmake -B $(BUILD_DIR) \
 		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
-		-DBFC_WITH_ZSTD=ON
+		-DBFC_BUILD_TESTS=ON\
+		-DBFC_WITH_ZSTD=ON \
 		-DBFC_WITH_SODIUM=ON
 
 # Build the project

--- a/include/bfc.h
+++ b/include/bfc.h
@@ -65,7 +65,8 @@ int bfc_create(const char* filename, uint32_t block_size, uint64_t features, bfc
 int bfc_add_file(bfc_t* w, const char* container_path, FILE* src, uint32_t mode, uint64_t mtime_ns,
                  uint32_t* out_crc);
 int bfc_add_dir(bfc_t* w, const char* container_dir, uint32_t mode, uint64_t mtime_ns);
-int bfc_add_symlink(bfc_t* w, const char* container_path, const char* link_target, uint32_t mode, uint64_t mtime_ns);
+int bfc_add_symlink(bfc_t* w, const char* container_path, const char* link_target, uint32_t mode,
+                    uint64_t mtime_ns);
 
 /* --- Compression Configuration --- */
 int bfc_set_compression(bfc_t* w, uint8_t comp_type, int level);

--- a/include/bfc.h
+++ b/include/bfc.h
@@ -65,6 +65,7 @@ int bfc_create(const char* filename, uint32_t block_size, uint64_t features, bfc
 int bfc_add_file(bfc_t* w, const char* container_path, FILE* src, uint32_t mode, uint64_t mtime_ns,
                  uint32_t* out_crc);
 int bfc_add_dir(bfc_t* w, const char* container_dir, uint32_t mode, uint64_t mtime_ns);
+int bfc_add_symlink(bfc_t* w, const char* container_path, const char* link_target, uint32_t mode, uint64_t mtime_ns);
 
 /* --- Compression Configuration --- */
 int bfc_set_compression(bfc_t* w, uint8_t comp_type, int level);

--- a/src/cli/cmd_create.c
+++ b/src/cli/cmd_create.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#define _GNU_SOURCE
 #include "cli.h"
 #include <dirent.h>
 #include <errno.h>

--- a/src/cli/cmd_create.c
+++ b/src/cli/cmd_create.c
@@ -232,7 +232,8 @@ static int add_file_to_container(bfc_t* writer, const char* file_path, const cha
   return 0;
 }
 
-static int add_symlink_to_container(bfc_t* writer, const char* link_path, const char* container_path) {
+static int add_symlink_to_container(bfc_t* writer, const char* link_path,
+                                    const char* container_path) {
   print_verbose("Adding symlink: %s -> %s", link_path, container_path);
 
   // Read the symlink target

--- a/src/cli/cmd_extract.c
+++ b/src/cli/cmd_extract.c
@@ -320,7 +320,8 @@ static int extract_directory(const char* output_path, const bfc_entry_t* entry, 
   return 0;
 }
 
-static int extract_symlink(bfc_t* reader, const bfc_entry_t* entry, const char* output_path, int force) {
+static int extract_symlink(bfc_t* reader, const bfc_entry_t* entry, const char* output_path,
+                           int force) {
   // Check if file exists
   struct stat st;
   if (lstat(output_path, &st) == 0) {
@@ -368,7 +369,8 @@ static int extract_symlink(bfc_t* reader, const bfc_entry_t* entry, const char* 
   };
 
   if (lutimes(output_path, times) != 0) {
-    print_verbose("Warning: cannot set timestamps on symlink '%s': %s", output_path, strerror(errno));
+    print_verbose("Warning: cannot set timestamps on symlink '%s': %s", output_path,
+                  strerror(errno));
   }
 
   if (!g_options.quiet) {

--- a/src/cli/cmd_info.c
+++ b/src/cli/cmd_info.c
@@ -157,6 +157,7 @@ typedef struct {
   int total_entries;
   int total_files;
   int total_dirs;
+  int total_symlinks;
   uint64_t total_size;
   uint64_t total_compressed_size;
   int show_detailed;
@@ -173,6 +174,8 @@ static int stats_callback(const bfc_entry_t* entry, void* user) {
     ctx->total_compressed_size += entry->obj_size;
   } else if (S_ISDIR(entry->mode)) {
     ctx->total_dirs++;
+  } else if (S_ISLNK(entry->mode)) {
+    ctx->total_symlinks++;
   }
 
   if (ctx->show_detailed) {
@@ -213,7 +216,7 @@ static void show_container_info(bfc_t* reader, const char* container_file, int s
   }
 
   // Gather statistics
-  stats_context_t ctx = {0, 0, 0, 0, 0, show_detailed};
+  stats_context_t ctx = {0, 0, 0, 0, 0, 0, show_detailed};
 
   if (show_detailed) {
     printf("Entries:\n");
@@ -236,6 +239,9 @@ static void show_container_info(bfc_t* reader, const char* container_file, int s
   printf("  Total entries: %d\n", ctx.total_entries);
   printf("  Files: %d\n", ctx.total_files);
   printf("  Directories: %d\n", ctx.total_dirs);
+  if (ctx.total_symlinks > 0) {
+    printf("  Symlinks: %d\n", ctx.total_symlinks);
+  }
 
   if (has_encryption) {
     printf("  Encryption: ChaCha20-Poly1305\n");
@@ -276,6 +282,7 @@ static void show_entry_info(bfc_t* reader, const char* path) {
   printf("Entry: %s\n", entry.path);
   printf("Type: %s\n", S_ISDIR(entry.mode)   ? "Directory"
                        : S_ISREG(entry.mode) ? "Regular file"
+                       : S_ISLNK(entry.mode) ? "Symlink"
                                              : "Special file");
   printf("Mode: %s (0%04o)\n", mode_str, entry.mode & 0777);
   printf("Size: %s\n", size_str);

--- a/src/cli/cmd_list.c
+++ b/src/cli/cmd_list.c
@@ -116,6 +116,16 @@ static void format_file_mode(uint32_t mode, char* buffer) {
     buffer[0] = 'd';
   else if (S_ISREG(mode))
     buffer[0] = '-';
+  else if (S_ISLNK(mode))
+    buffer[0] = 'l';
+  else if (S_ISBLK(mode))
+    buffer[0] = 'b';
+  else if (S_ISCHR(mode))
+    buffer[0] = 'c';
+  else if (S_ISFIFO(mode))
+    buffer[0] = 'p';
+  else if (S_ISSOCK(mode))
+    buffer[0] = 's';
   else
     buffer[0] = '?';
 

--- a/src/lib/bfc_writer.c
+++ b/src/lib/bfc_writer.c
@@ -524,7 +524,8 @@ int bfc_add_dir(bfc_t* w, const char* container_dir, uint32_t mode, uint64_t mti
   return result;
 }
 
-int bfc_add_symlink(bfc_t* w, const char* container_path, const char* link_target, uint32_t mode, uint64_t mtime_ns) {
+int bfc_add_symlink(bfc_t* w, const char* container_path, const char* link_target, uint32_t mode,
+                    uint64_t mtime_ns) {
   if (!w || !container_path || !link_target || w->finished) {
     return BFC_E_INVAL;
   }

--- a/src/lib/bfc_writer.c
+++ b/src/lib/bfc_writer.c
@@ -524,6 +524,91 @@ int bfc_add_dir(bfc_t* w, const char* container_dir, uint32_t mode, uint64_t mti
   return result;
 }
 
+int bfc_add_symlink(bfc_t* w, const char* container_path, const char* link_target, uint32_t mode, uint64_t mtime_ns) {
+  if (!w || !container_path || !link_target || w->finished) {
+    return BFC_E_INVAL;
+  }
+
+  // Normalize path
+  char* norm_path;
+  int result = bfc_path_normalize(container_path, &norm_path);
+  if (result != BFC_OK) {
+    return result;
+  }
+
+  uint64_t obj_start = w->current_offset;
+  size_t target_len = strlen(link_target);
+
+  // Create object header for symlink
+  struct bfc_obj_hdr obj_hdr = {.type = BFC_TYPE_SYMLINK,
+                                .comp = BFC_COMP_NONE,
+                                .enc = BFC_ENC_NONE,
+                                .reserved = 0,
+                                .name_len = (uint16_t) strlen(norm_path),
+                                .padding = 0,
+                                .mode = mode | S_IFLNK, // Add symlink type bits
+                                .mtime_ns = mtime_ns,
+                                .orig_size = target_len,
+                                .enc_size = target_len,
+                                .crc32c = 0}; // Will be calculated below
+
+  // Calculate CRC32C of link target
+  uint32_t crc = bfc_crc32c_compute(link_target, target_len);
+  obj_hdr.crc32c = crc;
+
+  // Write object header
+  if (fwrite(&obj_hdr, 1, sizeof(obj_hdr), w->file) != sizeof(obj_hdr)) {
+    bfc_path_free(norm_path);
+    return BFC_E_IO;
+  }
+
+  // Write path
+  if (fwrite(norm_path, 1, obj_hdr.name_len, w->file) != obj_hdr.name_len) {
+    bfc_path_free(norm_path);
+    return BFC_E_IO;
+  }
+
+  // Write padding after path to 16-byte boundary
+  size_t hdr_name_size = sizeof(obj_hdr) + obj_hdr.name_len;
+  size_t padding = bfc_padding_size(hdr_name_size, BFC_ALIGN);
+  if (padding > 0) {
+    uint8_t pad[BFC_ALIGN] = {0};
+    if (fwrite(pad, 1, padding, w->file) != padding) {
+      bfc_path_free(norm_path);
+      return BFC_E_IO;
+    }
+  }
+
+  // Write link target data
+  if (fwrite(link_target, 1, target_len, w->file) != target_len) {
+    bfc_path_free(norm_path);
+    return BFC_E_IO;
+  }
+
+  // Write padding after target to 16-byte boundary
+  size_t target_padding = bfc_padding_size(target_len, BFC_ALIGN);
+  if (target_padding > 0) {
+    uint8_t pad[BFC_ALIGN] = {0};
+    if (fwrite(pad, 1, target_padding, w->file) != target_padding) {
+      bfc_path_free(norm_path);
+      return BFC_E_IO;
+    }
+  }
+
+  uint64_t obj_size = sizeof(obj_hdr) + obj_hdr.name_len + padding + target_len + target_padding;
+
+  // Add to index
+  result = add_path_to_index(w, norm_path, obj_start, obj_size, mode | S_IFLNK, mtime_ns,
+                             BFC_COMP_NONE, BFC_ENC_NONE, target_len, crc);
+
+  if (result == BFC_OK) {
+    w->current_offset = obj_start + obj_size;
+  }
+
+  bfc_path_free(norm_path);
+  return result;
+}
+
 static int index_entry_compare(const void* a, const void* b) {
   const bfc_index_entry_t* ea = (const bfc_index_entry_t*) a;
   const bfc_index_entry_t* eb = (const bfc_index_entry_t*) b;


### PR DESCRIPTION
This pull request adds full support for symbolic links (symlinks) to the container format and CLI tools. The changes include the ability to add, list, extract, and display information about symlinks, as well as improvements to the test suite to verify symlink handling. The implementation ensures correct preservation of symlink targets, metadata, and compatibility with compression and encryption.

**Symlink Support:**

* Added a new API function `bfc_add_symlink` and its implementation to allow adding symlinks to containers, storing their target and metadata (`include/bfc.h`, `src/lib/bfc_writer.c`). [[1]](diffhunk://#diff-7bbc62de295f4e5111f845e0a53f60eae872122bcfd04b13f91fefe596657d91R68-R69) [[2]](diffhunk://#diff-a8aefdd13020a9f01d7a096ad3fc7ebd6f810f01602177f1b36d63e1549632b3R527-R612)
* Updated the `cmd_create` command to detect symlinks during both directory and file processing, and to add them using the new API (`src/cli/cmd_create.c`). [[1]](diffhunk://#diff-a3aaddcafbd91f0eb75c4d6d7826d5588763dbdd67f13cc0ca93f48532ec6417R235-R270) [[2]](diffhunk://#diff-a3aaddcafbd91f0eb75c4d6d7826d5588763dbdd67f13cc0ca93f48532ec6417L252-R298) [[3]](diffhunk://#diff-a3aaddcafbd91f0eb75c4d6d7826d5588763dbdd67f13cc0ca93f48532ec6417L420-R458) [[4]](diffhunk://#diff-a3aaddcafbd91f0eb75c4d6d7826d5588763dbdd67f13cc0ca93f48532ec6417R489-R495)

**Symlink Extraction:**

* Implemented extraction logic for symlinks, ensuring they are recreated as symlinks with the correct target and timestamps (`src/cli/cmd_extract.c`). [[1]](diffhunk://#diff-adc6a8359682648d57bbf88c56f45bb2d5e812a79d2b96ad99fe877c7f488f87R323-R383) [[2]](diffhunk://#diff-adc6a8359682648d57bbf88c56f45bb2d5e812a79d2b96ad99fe877c7f488f87R428-R429)
* Included `lutimes` usage to set symlink timestamps and improved error handling for existing files during extraction (`src/cli/cmd_extract.c`). [[1]](diffhunk://#diff-adc6a8359682648d57bbf88c56f45bb2d5e812a79d2b96ad99fe877c7f488f87R26) [[2]](diffhunk://#diff-adc6a8359682648d57bbf88c56f45bb2d5e812a79d2b96ad99fe877c7f488f87R323-R383)

**Symlink Information and Listing:**

* Updated the `cmd_info` and `cmd_list` commands to recognize and display symlinks, including type, count, and mode in summary and detailed outputs (`src/cli/cmd_info.c`, `src/cli/cmd_list.c`). [[1]](diffhunk://#diff-3c58a277d0cf8024671b63e6064ea29124ad94f09af871e0ef28b1a72db320d0R160) [[2]](diffhunk://#diff-3c58a277d0cf8024671b63e6064ea29124ad94f09af871e0ef28b1a72db320d0R177-R178) [[3]](diffhunk://#diff-3c58a277d0cf8024671b63e6064ea29124ad94f09af871e0ef28b1a72db320d0L216-R219) [[4]](diffhunk://#diff-3c58a277d0cf8024671b63e6064ea29124ad94f09af871e0ef28b1a72db320d0R242-R244) [[5]](diffhunk://#diff-3c58a277d0cf8024671b63e6064ea29124ad94f09af871e0ef28b1a72db320d0R285) [[6]](diffhunk://#diff-0c6f273a76ea91155addc20c0eb8583c2ec97a85addb47814c49671d29b6f329R119-R128)

**Testing and Build System:**

* Extended the CI workflow to thoroughly test symlink creation, listing, extraction, and compatibility with compression/encryption (`.github/workflows/ci.yml`).
* Modified the `Makefile` to enable building tests by default (`Makefile`).

These changes ensure that symbolic links are first-class citizens in the container format, with robust handling across all relevant CLI commands and test coverage.