### PR TITLE
Add FreeBSD build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A high-performance, single-file container format for storing files and directori
 - **Optional compression** - ZSTD compression with intelligent content analysis
 - **Optional encryption** - ChaCha20-Poly1305 AEAD with Argon2id key derivation
 - **Integrity validation** - CRC32C checksums with hardware acceleration
-- **Cross-platform** - Works on Linux, macOS, and other Unix systems
+- **Cross-platform** - Works on Linux, macOS, FreeBSD, and other Unix systems
 - **Crash-safe writes** - Atomic container creation with index at EOF
 - **Memory efficient** - Optimized for large containers and small memory footprint
 
@@ -53,6 +53,7 @@ cmake --build build
 **Optional dependencies:**
 - ZSTD library for compression support
 - libsodium for encryption support
+- pkg-config (or pkgconf on FreeBSD) for dependency detection
 
 ### Build from source
 
@@ -70,6 +71,20 @@ cmake --build build
 
 # Install system-wide
 sudo cmake --install build --prefix /usr/local
+```
+
+**FreeBSD-specific setup:**
+
+```bash
+# Install dependencies
+sudo pkg install cmake pkgconf libzstd libsodium
+
+# Build (uses gmake wrapper)
+make
+
+# Or use cmake directly
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DBFC_WITH_ZSTD=ON -DBFC_WITH_SODIUM=ON
+make -C build
 ```
 
 ### Build options
@@ -618,9 +633,9 @@ limitations under the License.
 - Initial release
 - Complete CLI tool with create, list, extract, info, verify commands
 - C library with full read/write API
-- Hardware-accelerated CRC32C
+- Hardware-accelerated CRC32C (SSE4.2 on x86_64)
 - Comprehensive test suite
-- Cross-platform support (Linux, macOS)
+- Cross-platform support (Linux, macOS, FreeBSD)
 - Performance optimizations
 - Security hardening
 

--- a/benchmarks/benchmark_encrypt.c
+++ b/benchmarks/benchmark_encrypt.c
@@ -344,7 +344,7 @@ static int benchmark_encrypted_containers(void) {
         
         // Set decryption password if needed
         if (scenarios[sc].use_encryption) {
-            result = bfc_set_encryption_password(reader, "benchmark_pass", 14);
+            result = bfc_reader_set_encryption_password(reader, "benchmark_pass", 14);
             if (result != BFC_OK) {
                 printf("Failed to set decryption password: %d\n", result);
                 bfc_close_read(reader);

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -36,11 +36,10 @@ set(BFC_LIB_HEADERS
 add_library(bfc STATIC ${BFC_LIB_SOURCES})
 add_library(bfc_shared SHARED ${BFC_LIB_SOURCES})
 
-# Enable SSE4.2 for CRC32C hardware support on x86_64
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
-    set_source_files_properties(bfc_crc32c.c PROPERTIES
-        COMPILE_FLAGS "-msse4.2"
-    )
+# Enable SSE4.2 and CRC32 for hardware support on x86_64
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64")
+    target_compile_options(bfc PRIVATE -msse4.2 -mcrc32)
+    target_compile_options(bfc_shared PRIVATE -msse4.2 -mcrc32)
 endif()
 
 # Set properties for both libraries

--- a/src/lib/bfc_os.c
+++ b/src/lib/bfc_os.c
@@ -305,6 +305,8 @@ int bfc_os_advise_nocache(FILE* file) {
     return BFC_E_INVAL;
   int fd = fileno(file);
   posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+#else
+  (void) file; // Suppress unused parameter warning
 #endif
   return BFC_OK;
 }


### PR DESCRIPTION
Enable BFC to build successfully on FreeBSD by addressing platform-specific compiler requirements and API differences.

Changes:
- Add -mcrc32 flag for CRC32 intrinsics on x86_64/amd64 architectures
- Detect FreeBSD's 'amd64' architecture identifier (in addition to x86_64/AMD64)
- Fix unused parameter warning in bfc_os_advise_nocache() on FreeBSD
- Fix benchmark_encrypt.c to use correct reader API (bfc_reader_set_encryption_password)
- Update documentation to mention FreeBSD support and pkgconf requirement

Technical details:
- FreeBSD's Clang requires both -msse4.2 and -mcrc32 for _mm_crc32_* intrinsics
- CMAKE_SYSTEM_PROCESSOR returns "amd64" on FreeBSD (not "x86_64")
- Changed from set_source_files_properties to target_compile_options for proper flag application

Tested on FreeBSD 14.3-RELEASE with Clang 19.1.7.