### PR TITLE
fix(release): update version retrieval and enhance asset upload for Windows compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,8 @@ jobs:
 
       - name: Get version
         id: get_version
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        shell: bash
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Create release package (non-Windows)
         if: matrix.platform != 'windows'
@@ -464,28 +465,19 @@ jobs:
           hdiutil create -volname "BFC ${VERSION_NO_V}" -srcfolder dmg-contents -ov -format UDZO "${DMG_NAME}.dmg"
 
       - name: Upload Release Assets
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.get_version.outputs.version }}
         run: |
           echo "Current directory contents:"
           ls -la
-          
+
           echo "Looking for package files..."
-          find . -name "*.tar.gz" -o -name "*.deb" -o -name "*.rpm" -o -name "*.dmg" | head -20
-          
-          # Upload all package files to the existing release
-          for file in *.tar.gz *.deb *.rpm *.dmg; do
-            if [ -f "$file" ]; then
-              echo "Uploading $file to release ${VERSION}"
-              gh release upload "${VERSION}" "$file" --clobber
-            fi
+          find . -maxdepth 1 \( -name "*.tar.gz" -o -name "*.deb" -o -name "*.rpm" -o -name "*.dmg" -o -name "*.zip" \)
+
+          shopt -s nullglob
+          for file in *.tar.gz *.deb *.rpm *.dmg *.zip; do
+            echo "Uploading $file to release ${VERSION}"
+            gh release upload "${VERSION}" "$file" --clobber
           done
-          
-          # Also try to upload from current directory using find results
-          find . -maxdepth 1 \( -name "*.tar.gz" -o -name "*.deb" -o -name "*.rpm" -o -name "*.dmg" \) -exec bash -c '
-            for file; do
-              echo "Found and uploading: $file"
-              gh release upload "${{ steps.get_version.outputs.version }}" "$file" --clobber
-            done
-          ' _ {} +


### PR DESCRIPTION
This pull request makes several improvements to the release workflow in `.github/workflows/release.yml`, focusing on better shell handling and expanding the types of release assets handled. The changes ensure more robust and consistent execution of release steps, and add support for uploading `.zip` files as release assets.

**Shell handling improvements:**
* Explicitly sets the shell to `bash` for steps that require Bash-specific features, improving script reliability and compatibility. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L233-R234) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R468)

**Release asset handling enhancements:**
* Expands the list of files uploaded as release assets to include `.zip` files, in addition to `.tar.gz`, `.deb`, `.rpm`, and `.dmg` files.
* Simplifies and consolidates the upload logic by using `shopt -s nullglob` and a single `for` loop, removing redundant and complex `find`/`exec` commands.